### PR TITLE
Fix the Meson project name.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project('nvidia-egl-platform-base', 'c',
+project('egl-x11', 'c',
   version : '0.1',
   default_options : ['c_std=gnu99'],
 )


### PR DESCRIPTION
The name "nvidia-egl-platform-base" was left over from the base library that egl-x11 started with, and I forgot to change it.

So, this just changes the project name in the Meson file to "egl-x11".