### PR TITLE
Set version number to 1.0.0.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 project('egl-x11', 'c',
-  version : '0.1',
+  version : '1.0.0',
   default_options : ['c_std=gnu99'],
 )
 

--- a/src/x11/meson.build
+++ b/src/x11/meson.build
@@ -54,7 +54,7 @@ if get_option('xcb')
       dep_eglexternal,
     ],
     link_with: [ platform_base ],
-    version : '1',
+    version : meson.project_version(),
     gnu_symbol_visibility: 'hidden',
     install: true)
 
@@ -77,7 +77,7 @@ if enable_xlib
       dep_eglexternal,
     ],
     link_with: [ platform_base ],
-    version : '1',
+    version : meson.project_version(),
     gnu_symbol_visibility: 'hidden',
     install: true)
 


### PR DESCRIPTION
Set the package version number to 1.0.0, so that we can use that for an initial release tag.