### PR TITLE
Check if typeof is available for glvnd_list.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,11 @@ dep_threads = dependency('threads')
 dep_eglexternal = dependency('eglexternalplatform', version : ['>=1.2', '<2'])
 inc_base = include_directories('src/base')
 
+cc = meson.get_compiler('c')
+if cc.compiles('typeof(int *);', name : 'typeof')
+  add_project_arguments('-DHAVE_TYPEOF', language : ['c'])
+endif
+
 subdir('src/base')
 subdir('src/x11')
 

--- a/src/base/glvnd_list.h
+++ b/src/base/glvnd_list.h
@@ -282,6 +282,7 @@ glvnd_list_is_empty(struct glvnd_list *head)
  * support typeof() and fails with this implementation, please try a newer
  * compiler.
  */
+#warning "typeof() is not supported. The fallback for this is undefined behavior."
 #define __glvnd_container_of(ptr, sample, member)                            \
     (void *)((char *)(ptr)                                             \
             - ((char *)&(sample)->member - (char *)(sample)))


### PR DESCRIPTION
When I copied `glvnd_list.h` over from libglvnd, I forgot to also add the check in the Meson script for whether `typeof` is available. Without that, it ends up using a fallback path which contains undefined behavior. That, in turn, causes crashes if you compile using Clang.

So, this change just adds the missing Meson snippet.

The actual change is on the commit for the base library (before any of the X11 stuff) and then merged onto main, so that it'll still be easy to branch off from the base library to write a different platform library.