### PR TITLE
Use the correct Present event mask in eplX11CreateWindowSurface.

### DIFF
--- a/src/x11/x11-window.c
+++ b/src/x11/x11-window.c
@@ -1361,10 +1361,8 @@ EGLSurface eplX11CreateWindowSurface(EplPlatformData *plat, EplDisplay *pdpy, Ep
     pwin->present_event_id = xcb_generate_id(inst->conn);
     pwin->present_event = xcb_register_for_special_xge(inst->conn,
             &xcb_present_id, pwin->present_event_id, &pwin->present_event_stamp);
-    presentSelectCookie = xcb_present_select_input_checked(inst->conn, pwin->present_event_id, xwin,
-            XCB_PRESENT_EVENT_MASK_CONFIGURE_NOTIFY
-            | XCB_PRESENT_EVENT_MASK_COMPLETE_NOTIFY
-            | XCB_PRESENT_EVENT_MASK_IDLE_NOTIFY);
+    presentSelectCookie = xcb_present_select_input_checked(inst->conn,
+            pwin->present_event_id, xwin, eventMask);
     error = xcb_request_check(inst->conn, presentSelectCookie);
     if (error != NULL)
     {


### PR DESCRIPTION
If we've got explicit sync available, then egl-x11 will use the timeline release point to know when a buffer is idle, and so it doesn't need PresentIdleNotify events.

It already ignores any PresentIdleNotify events in that case, but it shouldn't select them in the first place.