### PR TITLE
Check for duplicate native drawables

### DIFF
--- a/src/x11/x11-pixmap.c
+++ b/src/x11/x11-pixmap.c
@@ -405,7 +405,7 @@ EGLSurface eplX11CreatePixmapSurface(EplPlatformData *plat, EplDisplay *pdpy, Ep
         EGLConfig config, void *native_surface, const EGLAttrib *attribs, EGLBoolean create_platform)
 {
     X11DisplayInstance *inst = pdpy->priv->inst;
-    xcb_pixmap_t xpix = 0;
+    xcb_pixmap_t xpix = eplX11GetNativeXID(pdpy, native_surface, create_platform);
     X11Pixmap *ppix = NULL;
     const EplConfig *configInfo;
     const EplFormatInfo *fmt;
@@ -423,20 +423,10 @@ EGLSurface eplX11CreatePixmapSurface(EplPlatformData *plat, EplDisplay *pdpy, Ep
     };
     EGLAttrib *internalAttribs = NULL;
 
-    if (create_platform)
+    if (xpix == 0)
     {
-        if (pdpy->platform_enum == EGL_PLATFORM_X11_KHR)
-        {
-            xpix = (uint32_t) *((unsigned long *) native_surface);
-        }
-        else
-        {
-            xpix = *((uint32_t *) native_surface);
-        }
-    }
-    else
-    {
-        xpix = (xcb_pixmap_t) ((uintptr_t) native_surface);
+        eplSetError(plat, EGL_BAD_NATIVE_PIXMAP, "Invalid native pixmap %p\n", native_surface);
+        return EGL_NO_SURFACE;
     }
 
     configInfo = eplConfigListFind(inst->configs, config);

--- a/src/x11/x11-platform.c
+++ b/src/x11/x11-platform.c
@@ -1401,3 +1401,34 @@ EGLBoolean eplX11WaitForFD(int syncfd)
     }
 }
 
+uint32_t eplX11GetNativeXID(EplDisplay *pdpy, void *native_surface, EGLBoolean create_platform)
+{
+    unsigned long xid = 0;
+
+    if (create_platform)
+    {
+        if (native_surface != NULL)
+        {
+            if (pdpy->platform_enum == EGL_PLATFORM_X11_KHR)
+            {
+                xid = *((unsigned long *) native_surface);
+            }
+            else
+            {
+                xid = *((uint32_t *) native_surface);
+            }
+        }
+    }
+    else
+    {
+        xid = (unsigned long) ((uintptr_t) native_surface);
+    }
+
+    // Make sure the value that we get actually fits in a 32-bit integer.
+    if (((uint32_t) xid) != xid)
+    {
+        return 0;
+    }
+
+    return xid;
+}

--- a/src/x11/x11-platform.h
+++ b/src/x11/x11-platform.h
@@ -355,6 +355,18 @@ xcb_connection_t *eplX11GetXCBConnection(void *native_display, int *ret_screen);
 X11XlibDisplayClosedData *eplX11AddXlibDisplayClosedCallback(void *xlib_native_display);
 
 /**
+ * Returns the XID for the native surface handle in one of the
+ * eglCreate*Surface functions.
+ *
+ * \param pdpy The EplDisplay struct
+ * \param native_surface The native surface handle
+ * \param create_platform True if this is for one of the
+ *      eglCreatePlatform*Surface functions.
+ * \return The XID value, or 0 if the native handle is invalid.
+ */
+uint32_t eplX11GetNativeXID(EplDisplay *pdpy, void *native_surface, EGLBoolean create_platform);
+
+/**
  * Returns true if a native display has been closed.
  *
  * Note that this only works for an Xlib Display, because XCB doesn't have any

--- a/src/x11/x11-window.c
+++ b/src/x11/x11-window.c
@@ -1245,7 +1245,7 @@ EGLSurface eplX11CreateWindowSurface(EplPlatformData *plat, EplDisplay *pdpy, Ep
         EGLConfig config, void *native_surface, const EGLAttrib *attribs, EGLBoolean create_platform)
 {
     X11DisplayInstance *inst = pdpy->priv->inst;
-    xcb_window_t xwin = 0;
+    xcb_window_t xwin = eplX11GetNativeXID(pdpy, native_surface, create_platform);
     xcb_void_cookie_t presentSelectCookie;
     xcb_get_window_attributes_cookie_t winodwAttribCookie;
     xcb_get_window_attributes_reply_t *windowAttribReply = NULL;
@@ -1265,20 +1265,10 @@ EGLSurface eplX11CreateWindowSurface(EplPlatformData *plat, EplDisplay *pdpy, Ep
     EGLAttrib *internalAttribs = NULL;
     uint32_t eventMask;
 
-    if (create_platform)
+    if (xwin == 0)
     {
-        if (pdpy->platform_enum == EGL_PLATFORM_X11_KHR)
-        {
-            xwin = (uint32_t) *((unsigned long *) native_surface);
-        }
-        else
-        {
-            xwin = *((uint32_t *) native_surface);
-        }
-    }
-    else
-    {
-        xwin = (xcb_window_t) ((uintptr_t) native_surface);
+        eplSetError(plat, EGL_BAD_NATIVE_WINDOW, "Invalid native window %p\n", native_surface);
+        return EGL_NO_SURFACE;
     }
 
     configInfo = eplConfigListFind(inst->configs, config);


### PR DESCRIPTION
By the EGL spec, you're not allowed to create more than one EGLSurface at a time from the same native window or pixmap, but egl-x11 doesn't check for that.

With this change, `eplX11CreateWindowSurface` and `eplX11CreatePixmapSurface` will scan the surface list to check for any existing drawables that use the same window/pixmap XID, and if it finds one, it'll fail with EGL_BAD_ALLOC.

Along with that, I also added a check so that if you pass NULL for a native handle to eglCreatePlatformWindow/PixmapSurface, then it'll fail cleanly with EGL_BAD_NATIVE_WINDOW/PIXMAP instead of segfaulting.