### PR TITLE
Increment version number to 1.0.1.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 project('egl-x11', 'c',
-  version : '1.0.0',
+  version : '1.0.1',
   default_options : ['c_std=gnu99'],
 )
 


### PR DESCRIPTION
Since we just tagged 1.0.0, bump the version number for the next release.