### PR TITLE
Fall back to gbm_bo_create_with_modifiers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Building and Installing
 
 This library depends on:
 - libxcb, libxcb-present, and libxcb-dri3, version 1.17.0
-- libgbm, version 21.3.0
+- libgbm, version 21.2.0
 - libdrm, version 2.4.99
 - libx11 (only if building the xlib library)
 - EGL headers

--- a/src/x11/x11-pixmap.c
+++ b/src/x11/x11-pixmap.c
@@ -90,7 +90,7 @@ static EGLPlatformColorBufferNVX AllocInternalBuffer(X11DisplayInstance *inst,
     struct gbm_bo *gbo = NULL;
     int fd = -1;
 
-    gbo = gbm_bo_create_with_modifiers2(inst->gbmdev,
+    gbo = inst->platform->priv->gbm.bo_create_with_modifiers2(inst->gbmdev,
             width, height, fmt->fourcc, fmt->modifiers, fmt->num_modifiers, 0);
     if (gbo == NULL)
     {

--- a/src/x11/x11-platform.h
+++ b/src/x11/x11-platform.h
@@ -129,6 +129,16 @@ struct _EplImplPlatform
                           uint32_t flags);
     } drm;
 
+    struct
+    {
+        struct gbm_bo * (* bo_create_with_modifiers2) (struct gbm_device *gbm,
+                uint32_t width, uint32_t height,
+                uint32_t format,
+                const uint64_t *modifiers,
+                const unsigned int count,
+                uint32_t flags);
+    } gbm;
+
     EGLBoolean timeline_funcs_supported;
 };
 

--- a/src/x11/x11-window.c
+++ b/src/x11/x11-window.c
@@ -362,7 +362,7 @@ static X11ColorBuffer *AllocOneColorBuffer(X11DisplayInstance *inst,
     glvnd_list_init(&buffer->entry);
     buffer->fd = -1;
 
-    buffer->gbo = gbm_bo_create_with_modifiers2(inst->gbmdev,
+    buffer->gbo = inst->platform->priv->gbm.bo_create_with_modifiers2(inst->gbmdev,
             width, height, fmt->fourcc, modifiers, num_modifiers, flags);
 
     if (buffer->gbo == NULL)


### PR DESCRIPTION
This relaxes the dependency for libgbm to allow a version that predates `gbm_surface_create_with_modifiers2`.

If `gbm_surface_create_with_modifiers2`, then it'll just fall back to calling `gbm_surface_create_with_modifiers` instead. We'll lose the scanout flag in that case, but it's still enough to pick a modifier that'll work, even if it picks something suboptimal.