### PR TITLE
Fix the passthrough call in eplX11SwapInterval.

### DIFF
--- a/src/x11/x11-window.c
+++ b/src/x11/x11-window.c
@@ -2382,7 +2382,7 @@ EGLBoolean eplX11SwapInterval(EGLDisplay edpy, EGLint interval)
         {
             // If we don't recognize he current EGLSurface, then just pass the
             // call through to the driver.
-            ret = pdpy->platform->priv->egl.SwapInterval(edpy, interval);
+            ret = pdpy->platform->priv->egl.SwapInterval(pdpy->internal_display, interval);
         }
     }
     else


### PR DESCRIPTION
This is a fix for #12, where eplX11SwapInterval is passing the external EGLDisplay through to the driver instead of the internal one, which causes the driver to recursively call back into egl-x11.