### PR TITLE
Add a hook function for eglQueryDisplayAttrib.

### DIFF
--- a/src/base/platform-impl.h
+++ b/src/base/platform-impl.h
@@ -276,6 +276,23 @@ typedef struct _EplImplFuncs
      * \return EGL_TRUE on success, EGL_FALSE on failure.
      */
     EGLBoolean (*WaitNative) (EplDisplay *pdpy, EplSurface *psurf);
+
+    /**
+     * Implements eglQueryDisplayAttribKHR/EXT/NV.
+     *
+     * This function is optional, if it's NULL, then the base library will
+     * handle any attributes that it implements internally, and forward the
+     * rest to the driver.
+     *
+     * If the platform doesn't recognize \p attrib, then it should forward the
+     * function to the driver.
+     *
+     * \param pdpy The EplDisplay struct
+     * \param attrib The attribute to look up.
+     * \param[out] value Returns the value of the attribute.
+     * \return EGL_TRUE on success, EGL_FALSE on failure.
+     */
+    EGLBoolean (*QueryDisplayAttrib) (EplDisplay *pdpy, EGLint attrib, EGLAttrib *ret_value);
 } EplImplFuncs;
 
 #ifdef __cplusplus


### PR DESCRIPTION
This adds a hook function for eglQueryDisplayAttribEXT/KHR/NV, so that querying EGL_TRACK_REFERENCES_KHR works correctly.

This adds a new optional `EplImplFuncs::QueryDisplayAttrib` function to handle any platform-specific queries, but egl-x11 doesn't need to do anything with it. The base library handles `EGL_TRACK_REFERENCES_KHR`, and forwarding to the driver is sufficient for `EGL_DEVICE_EXT`.