### PR TITLE
Call glFlush after eglCreateSync, not before

### DIFF
--- a/src/x11/x11-window.c
+++ b/src/x11/x11-window.c
@@ -1611,14 +1611,14 @@ static EGLBoolean SyncRendering(EplDisplay *pdpy, EplSurface *surf, X11ColorBuff
         return EGL_TRUE;
     }
 
-    pwin->inst->platform->priv->egl.Flush();
-
     sync = pwin->inst->platform->priv->egl.CreateSync(pwin->inst->internal_display->edpy,
             EGL_SYNC_NATIVE_FENCE_ANDROID, NULL);
     if (sync == EGL_NO_SYNC)
     {
         goto done;
     }
+
+    pwin->inst->platform->priv->egl.Flush();
 
     syncFd = pwin->inst->platform->priv->egl.DupNativeFenceFDANDROID(pwin->inst->internal_display->edpy, sync);
     if (syncFd < 0)


### PR DESCRIPTION
By the EGL_ANDROID_native_fence_sync spec, when you create a fence with eglCreateSync, the file descriptor isn't valid until the next glFlush, so we should be calling glFlush after eglCreateSync, not before.