### PR TITLE
egl-x11: Add support for tegradisp-drm

### DIFF
--- a/src/x11/x11-platform.c
+++ b/src/x11/x11-platform.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -500,6 +500,7 @@ static EGLDeviceEXT FindDeviceForFD(EplPlatformData *plat, int fd)
                 if (version->name != NULL)
                 {
                     if (strcmp(version->name, "nvidia-drm") == 0
+                            || strcmp(version->name, "tegradisp-drm") == 0
                             || strcmp(version->name, "tegra-udrm") == 0
                             || strcmp(version->name, "tegra") == 0)
                     {


### PR DESCRIPTION
This change adds support in the X11/XCB EGL Platform library for the tegradisp-drm DRM driver meant for Automotive (DRIVE OS) Tegra platforms.