### PR TITLE
Increment version number to 1.0.2.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 project('egl-x11', 'c',
-  version : '1.0.1',
+  version : '1.0.2',
   default_options : ['c_std=gnu99'],
 )
 


### PR DESCRIPTION
We just tagged 1.0.1, so bump the version number for the next version.