### PR TITLE
Don't close the syncfd in WaitImplicitFence.

### DIFF
--- a/src/x11/x11-window.c
+++ b/src/x11/x11-window.c
@@ -1710,7 +1710,6 @@ static EGLBoolean WaitImplicitFence(EplDisplay *pdpy, X11ColorBuffer *buffer)
     if (fd >= 0)
     {
         success = WaitForSyncFDGPU(pdpy->priv->inst, fd);
-        close(fd);
     }
 
     if (success)


### PR DESCRIPTION
This is a fix for the implicit sync path, where egl-x11 tries to close a syncfd after passing it to eglCreateSync. According to the EGL_ANDROID_native_fence_sync spec, the driver takes ownership of the file descriptor and closes it when appropriate.