### PR TITLE
Fix the error reporting in WaitTimelinePoint.

### DIFF
--- a/src/x11/x11-window.c
+++ b/src/x11/x11-window.c
@@ -1887,10 +1887,13 @@ static EGLBoolean WaitTimelinePoint(X11DisplayInstance *inst, X11Timeline *timel
                     DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT,
                     &first) == 0)
         {
+            success = EGL_TRUE;
+        }
+        else
+        {
             eplSetError(inst->platform, EGL_BAD_ALLOC,
                     "Internal error: drmSyncobjTimelineWait(WAIT_FOR_SUBMIT) failed: %s\n",
                     strerror(errno));
-            success = EGL_TRUE;
         }
     }
 


### PR DESCRIPTION
This fixes a bug in the fallback path for explicit sync. If using an EGLSync fails, but `drmSyncobjTimelineWait` succeeds, then egl-x11 currently returns success and reports an error.