### PR TITLE
Increment the version number to 1.0.3.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 project('egl-x11', 'c',
-  version : '1.0.2',
+  version : '1.0.3',
   default_options : ['c_std=gnu99'],
 )
 


### PR DESCRIPTION
Since we just tagged version 1.0.2, this bumps the version number again so we're ready the next release.