### PR TITLE
Use GL_FRONT for pixmaps, not GL_BACK.

### DIFF
--- a/src/x11/x11-pixmap.c
+++ b/src/x11/x11-pixmap.c
@@ -436,7 +436,7 @@ EGLSurface eplX11CreatePixmapSurface(EplPlatformData *plat, EplDisplay *pdpy, Ep
     EGLSurface esurf = EGL_NO_SURFACE;
     EGLAttrib buffers[] =
     {
-        GL_BACK, 0,
+        GL_FRONT, 0,
         EGL_PLATFORM_SURFACE_BLIT_TARGET_NVX, 0,
         EGL_PLATFORM_SURFACE_DAMAGE_CALLBACK_NVX, (EGLAttrib) PixmapDamageCallback,
         EGL_PLATFORM_SURFACE_DAMAGE_CALLBACK_PARAM_NVX, (EGLAttrib) surf,


### PR DESCRIPTION
The EGL spec is admittedly not very clear which buffer it's supposed to use in eglCreatePixmapSurface, but it does say that eglQuerySurface is supposed to return `EGL_SINGLE_BUFFER` for a pixmap, which would suggest that it should use GL_FRONT.

Using GL_FRONT is also consistent with GLX (which specifically says that the pixmap is the front-left buffer), and with the existing behavior in the NVIDIA driver for EGL on a regular Xorg server.