### PR TITLE
fix parameter validation

### DIFF
--- a/src/base/config-list.c
+++ b/src/base/config-list.c
@@ -258,6 +258,14 @@ EplConfig **eplConfigListChooseConfigs(EplPlatformData *platform, EGLDisplay edp
             }
             else if (attribs[i] == EGL_NATIVE_RENDERABLE)
             {
+                if (attribs[i + 1] != EGL_TRUE && attribs[i + 1] != EGL_FALSE
+                        && attribs[i + 1] != EGL_DONT_CARE)
+                {
+                    eplSetError(platform, EGL_BAD_ATTRIBUTE,
+                            "Invalid value 0x%04x for EGL_NATIVE_RENDERABLE", attribs[i + 1]);
+                    goto done;
+                }
+
                 nativeRenderable = attribs[i + 1];
             }
             else if (attribs[i] == EGL_NATIVE_VISUAL_TYPE)

--- a/src/x11/x11-window.c
+++ b/src/x11/x11-window.c
@@ -2277,6 +2277,13 @@ done:
 
 EGLBoolean eplX11SwapInterval(EplDisplay *pdpy, EplSurface *psurf, EGLint interval)
 {
+    if (pdpy->platform->egl.GetCurrentContext() == EGL_NO_CONTEXT)
+    {
+        eplSetError(pdpy->platform, EGL_BAD_CONTEXT, "eglSwapInterval called without a current context");
+        eplDisplayRelease(pdpy);
+        return EGL_FALSE;
+    }
+
     if (psurf->type == EPL_SURFACE_TYPE_WINDOW)
     {
         X11Window *pwin = (X11Window *) psurf->priv;


### PR DESCRIPTION
Add missing validation for EGL_NATIVE_RENDERABLE to eglChooseConfig.

Check if current thread has an EGL context attached in eglSwapInterval and return EGL_BAD_CONTEXT if not.

Fixes dEQP-EGL.functional.negative_api.*