### PR TITLE
base: fix eglSetDamageRegionKHR for non-postable surfaces

### DIFF
--- a/src/base/platform-base.c
+++ b/src/base/platform-base.c
@@ -148,6 +148,7 @@ EplPlatformData *eplPlatformBaseAllocate(int major, int minor,
         platform->egl.SwapBuffersWithDamage = driver->getProcAddress("eglSwapBuffersWithDamageEXT");
     }
     platform->egl.CreateStreamProducerSurfaceKHR = driver->getProcAddress("CreateStreamProducerSurfaceKHR");
+    platform->egl.SetDamageRegionKHR = driver->getProcAddress("eglSetDamageRegionKHR");
 
     if (platform->egl.QueryString == NULL
             || platform->egl.QueryString == NULL


### PR DESCRIPTION
When eglSetDamageRegionKHR is called on a surface not in the EPL surface list (e.g. a pbuffer), the previous code either forwarded the call to the driver (if the driver function pointer was set) or silently returned EGL_TRUE. The EGL_KHR_partial_update spec requires EGL_BAD_MATCH for non-postable surfaces.

Initialize egl.SetDamageRegionKHR in eplPlatformBaseAllocate so the driver function pointer is available. This enables the pass-through path for postable surfaces not tracked by the EPL, such as EGL stream producer surfaces created with eglCreateStreamProducerSurfaceKHR.

When the driver does not expose eglSetDamageRegionKHR, return EGL_BAD_MATCH rather than silently returning success. All postable surfaces tracked by the EPL (window and pixmap) are handled before reaching this point.

Fixes dEQP-EGL.functional.negative_partial_update.not_postable_surface