### PR TITLE
base: fix eglSwapInterval to return correct error without current context

### DIFF
--- a/src/base/platform-base.c
+++ b/src/base/platform-base.c
@@ -1299,7 +1299,10 @@ static EGLBoolean HookSwapInterval(EGLDisplay edpy, EGLint interval)
     }
     else
     {
-        eplSetError(pdpy->platform, EGL_BAD_SURFACE, "EGLDisplay %p is not current", edpy);
+        // Current display is not this display (or there is no current context).
+        // Pass through to the driver, which will return the appropriate error.
+        internal_edpy = pdpy->internal_display;
+        SwapInterval = pdpy->platform->egl.SwapInterval;
     }
 
     if (SwapInterval != NULL)


### PR DESCRIPTION
When eglSwapInterval is called with no current context, the EPL's HookSwapInterval returned EGL_BAD_SURFACE because the current display check fails. Pass through to the driver instead, which now returns EGL_BAD_CONTEXT via NvEglIntSwapInterval.

Fixes dEQP-EGL.functional.negative_api.swap_interval