### PR TITLE
egl-x11: fix eglChooseConfig treating zero-match result as error

### DIFF
--- a/src/base/config-list.c
+++ b/src/base/config-list.c
@@ -284,9 +284,26 @@ EplConfig **eplConfigListChooseConfigs(EplPlatformData *platform, EGLDisplay edp
     attribsCopy[numAttribs++] = EGL_DONT_CARE;
     attribsCopy[numAttribs] = EGL_NONE;
 
-    if (!platform->egl.ChooseConfig(edpy, attribsCopy, NULL, 0, &internalCount)
-            || internalCount <= 0)
+    if (!platform->egl.ChooseConfig(edpy, attribsCopy, NULL, 0, &internalCount))
     {
+        goto done;
+    }
+
+    /*
+     * Zero configs is a valid result meaning no configs match the
+     * requested attributes. Return success with an empty list.
+     */
+    if (internalCount == 0)
+    {
+        configs = malloc(sizeof(EplConfig *));
+        if (configs == NULL)
+        {
+            eplSetError(platform, EGL_BAD_ALLOC, "Out of memory");
+            goto done;
+        }
+        configs[0] = NULL;
+        matchCount = 0;
+        success = EGL_TRUE;
         goto done;
     }
 
@@ -298,8 +315,7 @@ EplConfig **eplConfigListChooseConfigs(EplPlatformData *platform, EGLDisplay edp
         goto done;
     }
 
-    if (!platform->egl.ChooseConfig(edpy, attribsCopy, internalConfigs, internalCount, &internalCount)
-            || internalCount <= 0)
+    if (!platform->egl.ChooseConfig(edpy, attribsCopy, internalConfigs, internalCount, &internalCount))
     {
         goto done;
     }


### PR DESCRIPTION
When eglChooseConfig returns EGL_TRUE with num_configs=0 (no configs match the requested attributes), the EPL treated this as an error and returned EGL_FALSE. A zero count is a valid result that should return EGL_TRUE with an empty config list.

Fixes dEQP-EGL.functional.multithread.config