### PR TITLE
egl-x11: fix eglCreatePixmapSurface error code priority

### DIFF
--- a/src/x11/x11-pixmap.c
+++ b/src/x11/x11-pixmap.c
@@ -447,16 +447,8 @@ EGLSurface eplX11CreatePixmapSurface(EplPlatformData *plat, EplDisplay *pdpy, Ep
     };
     EGLAttrib *internalAttribs = NULL;
 
-    if (xpix == 0)
-    {
-        eplSetError(plat, EGL_BAD_NATIVE_PIXMAP, "Invalid native pixmap %p\n", native_surface);
-        return EGL_NO_SURFACE;
-    }
-    if (!CheckExistingPixmap(pdpy, xpix, existing_surfaces))
-    {
-        return EGL_NO_SURFACE;
-    }
-
+    // Validate config before pixmap to match EGL spec error priority
+    // (EGL_BAD_CONFIG before EGL_BAD_NATIVE_PIXMAP).
     configInfo = eplConfigListFind(inst->configs, config);
     if (configInfo == NULL)
     {
@@ -466,6 +458,16 @@ EGLSurface eplX11CreatePixmapSurface(EplPlatformData *plat, EplDisplay *pdpy, Ep
     if (!(configInfo->surfaceMask & EGL_PIXMAP_BIT))
     {
         eplSetError(plat, EGL_BAD_CONFIG, "EGLConfig %p does not support pixmaps", config);
+        return EGL_NO_SURFACE;
+    }
+
+    if (xpix == 0)
+    {
+        eplSetError(plat, EGL_BAD_NATIVE_PIXMAP, "Invalid native pixmap %p\n", native_surface);
+        return EGL_NO_SURFACE;
+    }
+    if (!CheckExistingPixmap(pdpy, xpix, existing_surfaces))
+    {
         return EGL_NO_SURFACE;
     }
     fmt = eplFormatInfoLookup(configInfo->fourcc);


### PR DESCRIPTION
Validate EGLConfig before the native pixmap handle to match EGL CTS expectation.

The spec does not mandate error ordering, but CTS expects EGL_BAD_CONFIG before EGL_BAD_NATIVE_PIXMAP.

From the EGL 1.5 spec, section 3.1 ("Errors"):

"When an EGL function could potentially generate several different errors (for example, when passed both a bad attribute name, and a bad attribute value for a legal attribute name), the implementation may choose to generate any one of the applicable errors.

Any order is valid by the spec but CTS only accepts only this specific order. This should be fixed in CTS but that is a long process, fix it in the platform layer in the meanwhile.

Fixes dEQP-EGL.functional.negative_api.create_pixmap_surface